### PR TITLE
Modify eci.js to upsert all ECI pages

### DIFF
--- a/bin/config.js
+++ b/bin/config.js
@@ -84,9 +84,7 @@ const fetch = async (actionPage) => {
   //  console.log(t)
 };
 
-const push = async (id) => {
-  const local = read(id);
-  console.log(local);
+const apiLink = () => {
   const a = basicAuth({
     username: process.env.AUTH_USER,
     password: process.env.AUTH_PASSWORD,
@@ -94,11 +92,14 @@ const push = async (id) => {
   if (!process.env.AUTH_USER || !process.env.AUTH_PASSWORD) {
     console.error("need .env with AUTH_USER + AUTH_PASSWORD");
   }
-
-  let url = process.env.REACT_APP_API_URL || "https://api.proca.app/api"
-
+  let url = process.env.REACT_APP_API_URL || "https://api.proca.app/api";
   const c = link(url, a);
-  const actionPage = {
+  return c;
+};
+
+
+const actionPageFromLocalConfig = (id, local) => {
+  return {
     id: id,
     actionPage: {
       name: local.filename,
@@ -113,6 +114,13 @@ const push = async (id) => {
       })
     }
   };
+};
+
+const push = async (id) => {
+  const local = read(id);
+  console.log(local);
+  const c = apiLink();
+  const actionPage = actionPageFromLocalConfig(id, local);
 
   const { data, errors } = await request(
     c,
@@ -138,4 +146,4 @@ const pull = async (actionPage) => {
   return config;
 };
 
-module.exports = { pull, push, fetch, read, file, save };
+module.exports = { pull, push, fetch, read, file, save, apiLink, actionPageFromLocalConfig };

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@babel/cli": "^7.12.8",
     "@babel/node": "^7.12.1",
     "@babel/plugin-transform-react-jsx": "^7.12.5",
-    "@proca/api": "^0.2.0-beta.1",
+    "@proca/api": "0.2.0-beta.3",
     "@rescripts/cli": "0.0.14",
     "@rescripts/rescript-use-babel-config": "0.0.10",
     "babel-plugin-i18next-extract": "^0.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,10 +1694,10 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@proca/api@^0.2.0-beta.1":
-  version "0.2.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@proca/api/-/api-0.2.0-beta.1.tgz#3a13b2bf42faa1fd235eea585602a76423f92ebe"
-  integrity sha512-w5BSFftC2+YiXOOiFXTm/v/BST6DOMMp+bJM9mOp29h6SVjQjCv+WZKB8d2XeD0PXfbo9ts1dm7F8wi0elatsg==
+"@proca/api@0.2.0-beta.3":
+  version "0.2.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@proca/api/-/api-0.2.0-beta.3.tgz#ae6714d41fbc74edf251e7cc2d621237e9535732"
+  integrity sha512-YJsnZqz1L/4MNEuu7Ep2VYB4W0YihngxROWo7rQlWf/LqWVVooKL19yUIlqQ57mKoztgBLzVUoqcqy0nPiHWEA==
   dependencies:
     "@absinthe/socket-apollo-link" "^0.2.1"
     apollo-link "^1.2.14"


### PR DESCRIPTION
Usage:
- Decide that one AP is your "master copy" on which you work. It can be one of
the ECI pages, eg. english one.
- yarn pull PAGEID  to have its config in config/
- edit the config and dev it normally as you see fit.
- call ./bin/eci.js PAGEID
- this will:
  1. Read the config from config/PAGEID.json
  2. Read the ECI registeration number
  3. Read the json with name ${registration number}.json from confog/
  4. For each language: copy the master page config; put the locale and
  necessary ECI info
  5. upsert all these pages to the same campaign