### PR TITLE
702 force rerender on amount change

### DIFF
--- a/src/components/donate/Amount.js
+++ b/src/components/donate/Amount.js
@@ -14,6 +14,8 @@ import Frequencies from "./buttons/FrequencyButton";
 import Amounts from "./buttons/AmountButton";
 import { Alert } from "@material-ui/lab";
 
+import { PayPalScriptProvider } from "@paypal/react-paypal-js";
+
 const useStyles = makeStyles((theme) => ({
   amount: {
     width: "5em",
@@ -63,8 +65,21 @@ const DonateAmount = (props) => {
   }
 
   const [, setDonateStep] = useDonateStep();
-  const [, setData] = useData();
+  const [formData, setData] = useData();
   const [complete, setComplete] = useState(false);
+
+  const frequency = formData.frequency;
+
+  const providerOptions = {
+    "client-id": donateConfig.paypal.clientId,
+    currency: donateConfig.currency.code,
+  };
+
+  if (frequency !== "oneoff") {
+    providerOptions["intent"] = "subscription";
+    providerOptions["vault"] = "true";
+  }
+
 
   return (
     <Container id="proca-donate" className={classes.container}>
@@ -96,32 +111,35 @@ const DonateAmount = (props) => {
               {t("donation.amount.intro")}
             </Typography>
 
-            <Amounts />
+            <PayPalScriptProvider options={providerOptions}>
 
-            <Frequencies />
+              <Amounts />
 
-            <Typography paragraph variant="h6" gutterBottom color="textPrimary">
-              {t("donation.payment_methods.intro")}
-            </Typography>
-            {!config.component.donation.external && (
-              <PaymentMethodButtons
-                classes={classes}
-                onClickStripe={() => {
-                  setData("paymentMethod", "stripe");
-                  setDonateStep(1);
-                  props.done();
-                }}
-                onClickSepa={() => {
-                  setData("paymentMethod", "sepa");
-                  setDonateStep(1);
-                  props.done();
-                }}
-                onComplete={() => {
-                  setComplete(true);
-                  props.go("donate_Thanks");
-                }}
-              />
-            )}
+              <Frequencies />
+
+              <Typography paragraph variant="h6" gutterBottom color="textPrimary">
+                {t("donation.payment_methods.intro")}
+              </Typography>
+              {!config.component.donation.external && (
+                <PaymentMethodButtons
+                  classes={classes}
+                  onClickStripe={() => {
+                    setData("paymentMethod", "stripe");
+                    setDonateStep(1);
+                    props.done();
+                  }}
+                  onClickSepa={() => {
+                    setData("paymentMethod", "sepa");
+                    setDonateStep(1);
+                    props.done();
+                  }}
+                  onComplete={() => {
+                    setComplete(true);
+                    props.go("donate_Thanks");
+                  }}
+                />
+              )}
+            </PayPalScriptProvider>
           </CardContent>
         </Grid>
       </Grid>

--- a/src/components/donate/DonateTitle.js
+++ b/src/components/donate/DonateTitle.js
@@ -48,7 +48,6 @@ const DonateTitle = ({ showAverage = true }) => {
 
   if (showAverage && averages) {
     if (averages[frequency]) {
-      console.log(averages[frequency], frequency);
       subtitle = t("donation.average", {
         amount: formatMoneyAmount(averages[frequency])
       });

--- a/src/components/donate/Paypal.js
+++ b/src/components/donate/Paypal.js
@@ -1,34 +1,16 @@
 import React from "react";
 import useData from "../../hooks/useData";
-import { PayPalScriptProvider } from "@paypal/react-paypal-js";
 import PayPalButton from "./PayPalButton";
-import { useCampaignConfig } from "../../hooks/useConfig";
 
 const Paypal = ({ onError, onComplete }) => {
-  const config = useCampaignConfig();
-  const donateConfig = config.component.donation;
-
   const [formData] = useData();
-  const frequency = formData.frequency;
-
-  const providerOptions = {
-    "client-id": donateConfig.paypal.clientId,
-    currency: donateConfig.currency.code,
-  };
-
-  if (frequency !== "oneoff") {
-    providerOptions["intent"] = "subscription";
-    providerOptions["vault"] = "true";
-  }
 
   return (
-    <PayPalScriptProvider options={providerOptions}>
-      <PayPalButton
-        onComplete={onComplete}
-        onError={onError}
-        frequency={frequency}
-      />
-    </PayPalScriptProvider>
+    <PayPalButton
+      onComplete={onComplete}
+      onError={onError}
+      forceReRender={[formData.amount]}
+    />
   );
 };
 


### PR DESCRIPTION

    Issue #702 - Force PayPalButtons reload

    The closures created for PayPal callbacks need to
    get updated in the PayPal React Context. This change
    forces those updates using:

     - forceReRender parameter of PayPalButtons
     - sharing PayPalScriptProvider between frequency buttons
     and PayPal buttons
