### PR TITLE
Add plural to progressCounter translations if available

### DIFF
--- a/src/components/ProgressCounter.js
+++ b/src/components/ProgressCounter.js
@@ -73,9 +73,11 @@ export default function Progress(props) {
   const min = config.component.counter?.min | 0;
   if (!count || count <= min) return null;
 
+  const progress = count > 1 && t("progress_plural") !== "progress_plural" ? "progress_plural" : "progress";
+
   return (
     <Box className={classes.root}>
-      {t("progress", {
+      {t(`${progress}`, {
         count: formatNumber(count, separator),
         goal: formatNumber(goal, separator),
       })}

--- a/src/locales/hr/common.json
+++ b/src/locales/hr/common.json
@@ -113,8 +113,7 @@
     "invalid_domain": "{{domain}} ne može primati e-poštu"
   },
   "progress_0": "{{count}} potpis. Idemo na {{goal}}",
-  "progress_1": "{{count}} potpisa. Idemo na {{goal}}",
-  "progress_2": "{{count}} potpisa. Idemo na {{goal}}",
+  "progress_plural": "{{count}} potpisa. Idemo na {{goal}}",
   "register": "Dodaj moje ime",
   "share": {
     "intro": "Sjajno, hvala na podršci 👍. Za još veći utjecaj, podijeli ovu peticiju nadaleko i naširoko 🙏.",

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -113,7 +113,7 @@
     "invalid_domain": "{{domain}} não pode receber e-mails"
   },
   "progress": "{{count}} assinou. Vamos ao {{goal}}",
-  "progress_plural": "{{count}} assinaram. Vamos ao {{goal}}",
+  "progress_plural": "{{count}} assinaram. Vamos até {{goal}}",
   "register": "Acrescentar meu nome",
   "share": {
     "intro": "Ótimo, você assinou 👍. Para multiplicar o seu impacto, partilhe longe e longe para que todos vejam isto petition🙏.",


### PR DESCRIPTION
Some languages, like mine or Portuguese, have different forms of the expression  "progress": "{{count}} have signed. Let's go to {{goal}}", depending on whether it is one or more. 
Most locales already have progress and progress_plural versions (even if those are the same, as for English), but that option wasn't used. 
I refactored progressCounter to switch to progress_plural if count>1 and translation of  progress_plural exists. If no plural version, progress will be displayed as before.
