### PR TITLE
Remove flags for windows

### DIFF
--- a/src/components/Country.js
+++ b/src/components/Country.js
@@ -90,6 +90,7 @@ const Country = (props) => {
     } else {
       countries = addCountries(countriesJson, t);
     }
+
     const compare = new Intl.Collator(config.lang.substring(0, 2).toLowerCase())
       .compare;
     countries.sort((a, b) => compare(a.name, b.name));
@@ -141,6 +142,9 @@ const Country = (props) => {
 
   if (props.list === false) return null;
 
+  // Windows doesn't support flag emojis
+  const isWindows = navigator.userAgent.indexOf("Win") > -1 ? true : false;
+
   return (
     <TextField
       select
@@ -152,9 +156,12 @@ const Country = (props) => {
       }}
     >
       <option key="" value=""></option>
+
       {_countries.map((option) => (
         <option key={option.iso} value={option.iso}>
-          {(emoji(option.iso) ? emoji(option.iso) + " " : "") + option.name}
+          { !isWindows &&  (emoji(option.iso) ? emoji(option.iso) + " " : "") + option.name}
+          { isWindows && option.name}
+
         </option>
       ))}
     </TextField>

--- a/src/components/eci/Country.js
+++ b/src/components/eci/Country.js
@@ -77,6 +77,9 @@ const Country = (props) => {
   }, [register]);
 
   if (props.list === false) return null;
+
+  const isWindows = navigator.userAgent.indexOf("Win") > -1 ? true : false;
+
   return (
     <Container component="main" maxWidth="sm">
       <Grid container spacing={1}>
@@ -94,8 +97,8 @@ const Country = (props) => {
             <option key="" value=""></option>
             {countries.map((option) => (
               <option key={option.iso} value={option.iso}>
-                {(emoji(option.iso) ? emoji(option.iso) + " " : "") +
-                  option.name}
+                { !isWindows &&  (emoji(option.iso) ? emoji(option.iso) + " " : "") + option.name}
+                { isWindows && option.name}
               </option>
             ))}
           </TextField>


### PR DESCRIPTION
#833 
Windows don't support flag emojis, so I removed them for this  OS. Flag emojis will be visible on other platforms.
Before (on Windows):
![flag](https://user-images.githubusercontent.com/65791349/167795094-063e765f-d324-4964-90d9-6565299dcde4.png)
ECI before:
![eci-before](https://user-images.githubusercontent.com/65791349/167795145-5dd6cda3-ff06-4131-a7b8-70be9615a9bc.png)
After (Windows)
![flag-win-after](https://user-images.githubusercontent.com/65791349/167795120-4fc8dce1-1619-45ab-ae9d-c491255be5b9.png)
![eci-win-after](https://user-images.githubusercontent.com/65791349/167796071-4684dcf3-e0f2-4e61-8a28-65ac23205786.png)

Linux
![flagLlinux](https://user-images.githubusercontent.com/65791349/167795124-5db3fa3a-4449-47d4-b3b2-4f495cd14b51.png)
![eci-linux-after](https://user-images.githubusercontent.com/65791349/167795154-d117635c-81a5-4af3-a14b-86a85cb47086.png)

.